### PR TITLE
Correctly clone existing active context

### DIFF
--- a/context.js
+++ b/context.js
@@ -69,7 +69,7 @@ Namespace.prototype.get = function get(key) {
 
 Namespace.prototype.createContext = function createContext() {
   // Prototype inherit existing context if created a new child context within existing context.
-  let context = Object.create(this.active ? this.active : Object.prototype);
+  const context = this.active ? Object.assign({}, this.active) : {};
   context._ns_name = this.name;
   context.id = currentUid;
 


### PR DESCRIPTION
Hi,

From what I understand, nested contexts are permitted and values will be inherited, however within `createContext` it currently uses `Object.create()`, but that doesn't actually clone the active context (on Node v8.16.0 & v10.16.0):

```typescript
let context = Object.create(this.active ? this.active : Object.prototype);
```

Where I believe it should be using `Object.assign()` to clone the object:

```typescript
const context = this.active ? Object.assign({}, this.active) : {};
```

For example:

```typescript
const active = { _ns_name: '__ictx__', id: 145, a: -1, b: 2, c: 3, d: 4 };

Object.create(active);
// => {}
```

Whereas:

```typescript
const active = { _ns_name: '__ictx__', id: 145, a: -1, b: 2, c: 3, d: 4 };

Object.assign({}, active);
// => { _ns_name: '__ictx__', id: 145, a: -1, b: 2, c: 3, d: 4 }
```

Am I missing something, or is this a bug?

Thanks!