### PR TITLE
Fix for multiple instances

### DIFF
--- a/context-legacy.js
+++ b/context-legacy.js
@@ -374,7 +374,7 @@ function reset() {
   process.namespaces = Object.create(null);
 }
 
-process.namespaces = {};
+process.namespaces = process.namespaces || {};
 
 if (asyncHook._state && !asyncHook._state.enabled) {
   asyncHook.enable();

--- a/context.js
+++ b/context.js
@@ -450,7 +450,7 @@ function reset() {
   process.namespaces = Object.create(null);
 }
 
-process.namespaces = {};
+process.namespaces = process.namespaces || {};
 
 //const fs = require('fs');
 function debug2(...args) {


### PR DESCRIPTION
When you have cls-hooked in multiple libraries, process.namespaces is cleared when the second instance is loaded and prevent you the ability to access the first namespace.